### PR TITLE
Guard against missing file paths in download endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 # Others
 *.DS_Store
+RemoteControlApi/wwwroot/uploads/

--- a/RemoteControlApi/Controllers/ControlController.cs
+++ b/RemoteControlApi/Controllers/ControlController.cs
@@ -209,7 +209,10 @@ namespace RemoteControlApi.Controllers
             if (_appVersion.Files == null || !_appVersion.Files.TryGetValue(platform, out var fileInfo))
                 return NotFound(new { error = "No build available for this platform" });
 
-            var path = Path.Combine(StoreRoot, fileInfo.RelativePath);
+            var relPath = fileInfo.RelativePath;
+            if (string.IsNullOrEmpty(relPath))
+                return NotFound(new { error = "File path not specified" });
+            var path = Path.Combine(StoreRoot, relPath);
             if (!System.IO.File.Exists(path))
                 return NotFound(new { error = "File not found on server" });
 
@@ -233,7 +236,9 @@ namespace RemoteControlApi.Controllers
             if (_appVersion.Files == null || !_appVersion.Files.TryGetValue(platform, out var fileInfo))
                 return NotFound();
 
-            var path = Path.Combine(StoreRoot, fileInfo.RelativePath);
+            var relPathHead = fileInfo.RelativePath;
+            if (string.IsNullOrEmpty(relPathHead)) return NotFound();
+            var path = Path.Combine(StoreRoot, relPathHead);
             if (!System.IO.File.Exists(path)) return NotFound();
 
             Response.Headers[HeaderNames.ContentLength] = fileInfo.SizeBytes.ToString();

--- a/RemoteControlApi/Controllers/ControlController.cs
+++ b/RemoteControlApi/Controllers/ControlController.cs
@@ -78,7 +78,9 @@ namespace RemoteControlApi.Controllers
         {
             if (!ModelState.IsValid) return ValidationProblem(ModelState);
             message.TimestampUtc = DateTimeOffset.UtcNow;
-            message.Id = Guid.NewGuid().ToString("n");
+            message.Id = string.IsNullOrWhiteSpace(message.Id)
+                ? Guid.NewGuid().ToString("n")
+                : message.Id;
             _notifications.Enqueue(message);
             while (_notifications.Count > MaxNotifications && _notifications.TryDequeue(out _)) { }
             SetNoCache();
@@ -264,7 +266,7 @@ namespace RemoteControlApi.Controllers
     // ================== Models ==================
     public class NotificationMessage
     {
-        public string Id { get; set; } = default!;
+        public string? Id { get; set; }
         [Required, StringLength(120)] public string Title { get; set; } = default!;
         [Required, StringLength(4000)] public string Body { get; set; } = default!;
         public DateTimeOffset TimestampUtc { get; set; }

--- a/RemoteControlApi/Controllers/ControlController.cs
+++ b/RemoteControlApi/Controllers/ControlController.cs
@@ -125,6 +125,7 @@ namespace RemoteControlApi.Controllers
         [HttpPost("app-version/upload")]
         [RequestSizeLimit(1_500_000_000)] // ~1.5GB, điều chỉnh tuỳ nhu cầu
         [DisableRequestSizeLimit]
+        [Consumes("multipart/form-data")]
         public async Task<IActionResult> UploadBuild(
             [FromForm][Required] string latest,
             [FromForm][Required] string minSupported,
@@ -132,7 +133,7 @@ namespace RemoteControlApi.Controllers
             [FromForm] string? notesEn,
             [FromForm][Required] string platform,
             [FromForm] int? build,
-            [FromForm][Required] IFormFile file)
+            [Required] IFormFile file)
         {
             platform = platform.Trim().ToLowerInvariant();
             if (platform is not ("android" or "ios"))

--- a/RemoteControlApi/Controllers/ControlController.cs
+++ b/RemoteControlApi/Controllers/ControlController.cs
@@ -96,7 +96,8 @@ namespace RemoteControlApi.Controllers
             };
             if (file != null && file.Length > 0)
             {
-                var uploads = Path.Combine(AppContext.BaseDirectory, "wwwroot", "uploads");
+                var env = HttpContext.RequestServices.GetRequiredService<IWebHostEnvironment>();
+                var uploads = Path.Combine(env.WebRootPath, "uploads");
                 Directory.CreateDirectory(uploads);
                 var fileName = Guid.NewGuid().ToString("n") + Path.GetExtension(file.FileName);
                 var fullPath = Path.Combine(uploads, fileName);

--- a/RemoteControlApi/Model/NotiModel.cs
+++ b/RemoteControlApi/Model/NotiModel.cs
@@ -1,0 +1,38 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace RemoteControlApi.Model
+{
+    public class NotiModel
+    {
+        public class NotificationMessage
+        {
+            public string? Id { get; set; }
+            [Required, StringLength(120)] public string Title { get; set; } = default!;
+            [Required, StringLength(4000)] public string Body { get; set; } = default!;
+            public DateTimeOffset TimestampUtc { get; set; }
+            public string? FileUrl { get; set; }
+        }
+
+        public class AppVersionInfo
+        {
+            [Required] public string Latest { get; set; } = default!;
+            [Required] public string MinSupported { get; set; } = default!;
+            public string? NotesVi { get; set; }
+            public string? NotesEn { get; set; }
+            public int Build { get; set; }
+            public DateTimeOffset UpdatedAt { get; set; }
+            // "android" | "ios" -> file info
+            public Dictionary<string, AppFileInfo>? Files { get; set; }
+        }
+
+        public class AppFileInfo
+        {
+            public string? FileName { get; set; }
+            public string? RelativePath { get; set; }
+            public long SizeBytes { get; set; }
+            public string? Sha256 { get; set; }
+            public string? ContentType { get; set; }
+        }
+    }
+}
+

--- a/RemoteControlApi/Program.cs
+++ b/RemoteControlApi/Program.cs
@@ -1,25 +1,53 @@
-﻿// Program.cs
+﻿using Microsoft.AspNetCore.Http.Features;
+using Microsoft.OpenApi.Models;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
-    // Dùng FullName (kèm namespace) làm schemaId để không bị trùng
     c.CustomSchemaIds(t => t.FullName?.Replace('+', '.') ?? t.Name);
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "RemoteControlApi", Version = "v1" });
 });
+
+// (match với controller: ~1.5GB)
+builder.Services.Configure<FormOptions>(o => { o.MultipartBodyLengthLimit = 1_500_000_000; });
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
+// Bật Swagger cả Prod và set server URL theo request (tôn trọng PathBase)
+app.UseSwagger(c =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+    c.PreSerializeFilters.Add((swagger, httpReq) =>
+    {
+        var basePath = httpReq.PathBase.HasValue ? httpReq.PathBase.Value : string.Empty;
+        swagger.Servers = new List<OpenApiServer>
+        {
+            new OpenApiServer { Url = $"{httpReq.Scheme}://{httpReq.Host.Value}{basePath}" }
+        };
+    });
+});
+app.UseSwaggerUI(c =>
+{
+    c.SwaggerEndpoint("v1/swagger.json", "RemoteControlApi v1");
+    c.RoutePrefix = "swagger"; // => /<base>/swagger
+});
 
+// Static files (uploads,…)
 app.UseDefaultFiles();
 app.UseStaticFiles();
 
 app.UseHttpsRedirection();
+
 app.MapControllers();
+
+// Redirect "/" -> "/<base>/swagger"
+app.MapGet("/", ctx =>
+{
+    var basePath = ctx.Request.PathBase.HasValue ? ctx.Request.PathBase.Value : string.Empty;
+    ctx.Response.Redirect($"{basePath}/swagger", permanent: false);
+    return Task.CompletedTask;
+});
+
 app.Run();

--- a/RemoteControlApi/Program.cs
+++ b/RemoteControlApi/Program.cs
@@ -17,6 +17,9 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
 app.UseHttpsRedirection();
 app.MapControllers();
 app.Run();

--- a/RemoteControlApi/Properties/PublishProfiles/SendNoti.pubxml
+++ b/RemoteControlApi/Properties/PublishProfiles/SendNoti.pubxml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <DeleteExistingFiles>false</DeleteExistingFiles>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>bin\Release\net8.0\publish\</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <_TargetId>Folder</_TargetId>
+  </PropertyGroup>
+</Project>

--- a/RemoteControlApi/wwwroot/receive.html
+++ b/RemoteControlApi/wwwroot/receive.html
@@ -7,22 +7,23 @@
 </head>
 <body>
   <h1>Notifications</h1>
-  <button id="refresh">Refresh</button>
   <ul id="list"></ul>
   <script>
+    const list = document.getElementById('list');
+    function add(n) {
+      const li = document.createElement('li');
+      li.textContent = `${n.title}: ${n.body}`;
+      list.prepend(li);
+    }
     async function load() {
       const res = await fetch('/api/control/get-notifications');
       const json = await res.json();
-      const list = document.getElementById('list');
       list.innerHTML = '';
-      json.items.forEach(n => {
-        const li = document.createElement('li');
-        li.textContent = `${n.title}: ${n.body}`;
-        list.appendChild(li);
-      });
+      json.items.forEach(add);
     }
-    document.getElementById('refresh').addEventListener('click', load);
     load();
+    const evt = new EventSource('/api/control/notifications-stream');
+    evt.onmessage = e => add(JSON.parse(e.data));
   </script>
 </body>
 </html>

--- a/RemoteControlApi/wwwroot/receive.html
+++ b/RemoteControlApi/wwwroot/receive.html
@@ -1,80 +1,126 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <title>Notifications</title>
-  <link rel="stylesheet" href="style.css">
+    <meta charset="utf-8" />
+    <title>Notifications</title>
+    <style>
+        body {
+            font-family: system-ui, Arial, sans-serif;
+            margin: 24px;
+        }
+
+        ul {
+            padding-left: 18px;
+        }
+
+        li {
+            margin: 10px 0;
+        }
+
+        .preview-container {
+            margin-top: 6px;
+        }
+
+        img, video, iframe {
+            max-width: 560px;
+            max-height: 340px;
+            display: block;
+        }
+    </style>
 </head>
 <body>
-  <h1>Notifications</h1>
-  <ul id="list"></ul>
-  <script>
-    const list = document.getElementById('list');
-      function add(n) {
-        if (n.message) n = n.message;
-        const li = document.createElement('li');
-        const title = n.title ?? n.Title ?? '';
-        const body = n.body ?? n.Body ?? '';
-        li.textContent = `${title}: ${body}`;
-        const url = n.fileUrl ?? n.FileUrl;
-        if (url) {
-          const previewBtn = document.createElement('button');
-          previewBtn.textContent = 'Preview';
-          const downloadLink = document.createElement('a');
-          downloadLink.href = url;
-          const lowerUrl = url.toLowerCase();
-          downloadLink.textContent = lowerUrl.endsWith('.apk') ? 'Install APK' : 'Download';
-          downloadLink.download = '';
-          downloadLink.target = '_blank';
-          downloadLink.style.marginLeft = '8px';
-          li.appendChild(previewBtn);
-          li.appendChild(downloadLink);
+    <h1>Notifications</h1>
+    <ul id="list"></ul>
 
-          const preview = document.createElement('div');
-          preview.className = 'preview-container';
-          preview.style.display = 'none';
-          li.appendChild(preview);
+    <script>
+        const list = document.getElementById('list');
 
-          previewBtn.addEventListener('click', () => {
-            if (preview.style.display === 'none') {
-              preview.innerHTML = '';
-              const lower = url.toLowerCase();
-              if (lower.match(/\.(png|jpe?g|gif|bmp|webp)$/)) {
-                const img = document.createElement('img');
-                img.src = url;
-                preview.appendChild(img);
-              } else if (lower.match(/\.(mp4|webm|ogg)$/)) {
-                const video = document.createElement('video');
-                video.src = url;
-                video.controls = true;
-                preview.appendChild(video);
-              } else if (lower.match(/\.(mp3|wav|ogg)$/)) {
-                const audio = document.createElement('audio');
-                audio.src = url;
-                audio.controls = true;
-                preview.appendChild(audio);
-              } else {
-                const frame = document.createElement('iframe');
-                frame.src = url;
-                preview.appendChild(frame);
-              }
-              preview.style.display = 'block';
-            } else {
-              preview.style.display = 'none';
+        // Luôn build URL dựa trên vị trí hiện tại (tự bao gồm /SendNoti nếu có)
+        const urlFrom = (path) => new URL(path, window.location).toString();
+
+        function add(n) {
+            if (n.message) n = n.message; // server đang bọc { status, message }
+            const li = document.createElement('li');
+
+            const title = n.title ?? n.Title ?? '';
+            const body = n.body ?? n.Body ?? '';
+            li.textContent = `${title}: ${body}`;
+
+            const url = n.fileUrl ?? n.FileUrl;
+            if (url) {
+                const previewBtn = document.createElement('button');
+                previewBtn.textContent = 'Preview';
+
+                const downloadLink = document.createElement('a');
+                downloadLink.href = urlFrom(url); // chuẩn hoá URL (kể cả trường hợp server trả bắt đầu bằng "/")
+                const lowerUrl = downloadLink.href.toLowerCase();
+                downloadLink.textContent = lowerUrl.endsWith('.apk') ? 'Install APK' : 'Download';
+                downloadLink.download = '';
+                downloadLink.target = '_blank';
+                downloadLink.style.marginLeft = '8px';
+
+                li.appendChild(previewBtn);
+                li.appendChild(downloadLink);
+
+                const preview = document.createElement('div');
+                preview.className = 'preview-container';
+                preview.style.display = 'none';
+                li.appendChild(preview);
+
+                previewBtn.addEventListener('click', () => {
+                    if (preview.style.display === 'none') {
+                        preview.innerHTML = '';
+                        const lower = lowerUrl;
+                        if (lower.match(/\.(png|jpe?g|gif|bmp|webp)$/)) {
+                            const img = document.createElement('img');
+                            img.src = downloadLink.href;
+                            preview.appendChild(img);
+                        } else if (lower.match(/\.(mp4|webm|ogg)$/)) {
+                            const video = document.createElement('video');
+                            video.src = downloadLink.href;
+                            video.controls = true;
+                            preview.appendChild(video);
+                        } else if (lower.match(/\.(mp3|wav|ogg)$/)) {
+                            const audio = document.createElement('audio');
+                            audio.src = downloadLink.href;
+                            audio.controls = true;
+                            preview.appendChild(audio);
+                        } else {
+                            const frame = document.createElement('iframe');
+                            frame.src = downloadLink.href;
+                            frame.width = 560;
+                            frame.height = 340;
+                            preview.appendChild(frame);
+                        }
+                        preview.style.display = 'block';
+                    } else {
+                        preview.style.display = 'none';
+                    }
+                });
             }
-          });
+
+            list.prepend(li);
         }
-        list.prepend(li);
-      }
-    async function load() {
-      const res = await fetch('/api/control/get-notifications');
-      const json = await res.json();
-      list.innerHTML = '';
-      json.items.forEach(add);
-    }
-    load();
-    const evt = new EventSource('/api/control/notifications-stream');
-    evt.onmessage = e => add(JSON.parse(e.data));
-  </script>
+
+        async function load() {
+            const res = await fetch(urlFrom('api/control/get-notifications'));
+            if (!res.ok) {
+                list.innerHTML = `<li>Load failed: ${res.status}</li>`;
+                return;
+            }
+            const json = await res.json();
+            list.innerHTML = '';
+            (json.items || []).forEach(add);
+        }
+
+        load();
+
+        // SSE phải dùng URL đúng base
+        const evt = new EventSource(urlFrom('api/control/notifications-stream'));
+        evt.onmessage = e => add(JSON.parse(e.data));
+        evt.onerror = () => {
+            // optional: auto-reconnect (EventSource tự reconnect mặc định)
+        };
+    </script>
 </body>
 </html>

--- a/RemoteControlApi/wwwroot/receive.html
+++ b/RemoteControlApi/wwwroot/receive.html
@@ -18,11 +18,50 @@
         li.textContent = `${title}: ${body}`;
         const url = n.fileUrl ?? n.FileUrl;
         if (url) {
-          const link = document.createElement('a');
-          link.href = url;
-          link.textContent = ' (file)';
-          link.target = '_blank';
-          li.appendChild(link);
+          const previewBtn = document.createElement('button');
+          previewBtn.textContent = 'Preview';
+          const downloadLink = document.createElement('a');
+          downloadLink.href = url;
+          downloadLink.textContent = 'Download';
+          downloadLink.download = '';
+          downloadLink.target = '_blank';
+          downloadLink.style.marginLeft = '8px';
+          li.appendChild(previewBtn);
+          li.appendChild(downloadLink);
+
+          const preview = document.createElement('div');
+          preview.className = 'preview-container';
+          preview.style.display = 'none';
+          li.appendChild(preview);
+
+          previewBtn.addEventListener('click', () => {
+            if (preview.style.display === 'none') {
+              preview.innerHTML = '';
+              const lower = url.toLowerCase();
+              if (lower.match(/\.(png|jpe?g|gif|bmp|webp)$/)) {
+                const img = document.createElement('img');
+                img.src = url;
+                preview.appendChild(img);
+              } else if (lower.match(/\.(mp4|webm|ogg)$/)) {
+                const video = document.createElement('video');
+                video.src = url;
+                video.controls = true;
+                preview.appendChild(video);
+              } else if (lower.match(/\.(mp3|wav|ogg)$/)) {
+                const audio = document.createElement('audio');
+                audio.src = url;
+                audio.controls = true;
+                preview.appendChild(audio);
+              } else {
+                const frame = document.createElement('iframe');
+                frame.src = url;
+                preview.appendChild(frame);
+              }
+              preview.style.display = 'block';
+            } else {
+              preview.style.display = 'none';
+            }
+          });
         }
         list.prepend(li);
       }

--- a/RemoteControlApi/wwwroot/receive.html
+++ b/RemoteControlApi/wwwroot/receive.html
@@ -22,7 +22,8 @@
           previewBtn.textContent = 'Preview';
           const downloadLink = document.createElement('a');
           downloadLink.href = url;
-          downloadLink.textContent = 'Download';
+          const lowerUrl = url.toLowerCase();
+          downloadLink.textContent = lowerUrl.endsWith('.apk') ? 'Install APK' : 'Download';
           downloadLink.download = '';
           downloadLink.target = '_blank';
           downloadLink.style.marginLeft = '8px';

--- a/RemoteControlApi/wwwroot/receive.html
+++ b/RemoteControlApi/wwwroot/receive.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Notifications</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Notifications</h1>
+  <button id="refresh">Refresh</button>
+  <ul id="list"></ul>
+  <script>
+    async function load() {
+      const res = await fetch('/api/control/get-notifications');
+      const json = await res.json();
+      const list = document.getElementById('list');
+      list.innerHTML = '';
+      json.items.forEach(n => {
+        const li = document.createElement('li');
+        li.textContent = `${n.title}: ${n.body}`;
+        list.appendChild(li);
+      });
+    }
+    document.getElementById('refresh').addEventListener('click', load);
+    load();
+  </script>
+</body>
+</html>

--- a/RemoteControlApi/wwwroot/receive.html
+++ b/RemoteControlApi/wwwroot/receive.html
@@ -10,11 +10,22 @@
   <ul id="list"></ul>
   <script>
     const list = document.getElementById('list');
-    function add(n) {
-      const li = document.createElement('li');
-      li.textContent = `${n.title}: ${n.body}`;
-      list.prepend(li);
-    }
+      function add(n) {
+        if (n.message) n = n.message;
+        const li = document.createElement('li');
+        const title = n.title ?? n.Title ?? '';
+        const body = n.body ?? n.Body ?? '';
+        li.textContent = `${title}: ${body}`;
+        const url = n.fileUrl ?? n.FileUrl;
+        if (url) {
+          const link = document.createElement('a');
+          link.href = url;
+          link.textContent = ' (file)';
+          link.target = '_blank';
+          li.appendChild(link);
+        }
+        list.prepend(li);
+      }
     async function load() {
       const res = await fetch('/api/control/get-notifications');
       const json = await res.json();

--- a/RemoteControlApi/wwwroot/send.html
+++ b/RemoteControlApi/wwwroot/send.html
@@ -1,41 +1,92 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <title>Send Notification</title>
-  <link rel="stylesheet" href="style.css">
+    <meta charset="utf-8" />
+    <title>Send Notification</title>
+    <style>
+        body {
+            font-family: system-ui, Arial, sans-serif;
+            margin: 24px;
+        }
+
+        form {
+            display: grid;
+            gap: 10px;
+            max-width: 520px;
+        }
+
+        label {
+            display: grid;
+            gap: 4px;
+        }
+
+        input, textarea {
+            padding: 6px 8px;
+        }
+
+        button {
+            padding: 8px 12px;
+        }
+
+        pre {
+            background: #111;
+            color: #eee;
+            padding: 12px;
+            overflow: auto;
+        }
+    </style>
 </head>
 <body>
     <h1>Send Notification</h1>
     <form id="notifyForm" enctype="multipart/form-data">
-      <label>ID (optional)
-        <input id="id" name="id">
-      </label>
-      <label>Title
-        <input id="title" name="title" required>
-      </label>
-      <label>Body
-        <textarea id="body" name="body" required></textarea>
-      </label>
-      <label>File
-        <input id="file" name="file" type="file">
-      </label>
-      <button type="submit">Send</button>
+        <label>
+            ID (optional)
+            <input id="id" name="id" />
+        </label>
+        <label>
+            Title
+            <input id="title" name="title" required />
+        </label>
+        <label>
+            Body
+            <textarea id="body" name="body" required></textarea>
+        </label>
+        <label>
+            File
+            <input id="file" name="file" type="file" />
+        </label>
+        <button type="submit">Send</button>
     </form>
-  <pre id="result"></pre>
-  <script>
-      const form = document.getElementById('notifyForm');
-      form.addEventListener('submit', async (e) => {
-        e.preventDefault();
-        const data = new FormData(form);
-        const res = await fetch('/api/control/send-notification', {
-          method: 'POST',
-          body: data
+
+    <h3>Result</h3>
+    <pre id="result"></pre>
+
+    <script>
+        const urlFrom = (path) => new URL(path, window.location).toString();
+
+        const form = document.getElementById('notifyForm');
+        const result = document.getElementById('result');
+
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            result.textContent = 'Sending...';
+
+            try {
+                const data = new FormData(form);
+                const res = await fetch(urlFrom('api/control/send-notification'), {
+                    method: 'POST',
+                    body: data
+                });
+
+                let bodyText = await res.text();
+                try { bodyText = JSON.stringify(JSON.parse(bodyText), null, 2); } catch { }
+                result.textContent = `${res.status} ${res.statusText}\n\n${bodyText}`;
+
+                if (res.ok) form.reset();
+            } catch (err) {
+                result.textContent = 'Error: ' + (err?.message || err);
+            }
         });
-        const json = await res.json();
-        document.getElementById('result').textContent = JSON.stringify(json, null, 2);
-        form.reset();
-      });
-  </script>
+    </script>
 </body>
 </html>

--- a/RemoteControlApi/wwwroot/send.html
+++ b/RemoteControlApi/wwwroot/send.html
@@ -8,6 +8,9 @@
 <body>
   <h1>Send Notification</h1>
   <form id="notifyForm">
+    <label>ID (optional)
+      <input id="id" name="id">
+    </label>
     <label>Title
       <input id="title" name="title" required>
     </label>
@@ -24,7 +27,7 @@
       const res = await fetch('/api/control/send-notification', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: form.title.value, body: form.body.value })
+        body: JSON.stringify({ id: form.id.value, title: form.title.value, body: form.body.value })
       });
       const json = await res.json();
       document.getElementById('result').textContent = JSON.stringify(json, null, 2);

--- a/RemoteControlApi/wwwroot/send.html
+++ b/RemoteControlApi/wwwroot/send.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Send Notification</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Send Notification</h1>
+  <form id="notifyForm">
+    <label>Title
+      <input id="title" name="title" required>
+    </label>
+    <label>Body
+      <textarea id="body" name="body" required></textarea>
+    </label>
+    <button type="submit">Send</button>
+  </form>
+  <pre id="result"></pre>
+  <script>
+    const form = document.getElementById('notifyForm');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const res = await fetch('/api/control/send-notification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: form.title.value, body: form.body.value })
+      });
+      const json = await res.json();
+      document.getElementById('result').textContent = JSON.stringify(json, null, 2);
+      form.reset();
+    });
+  </script>
+</body>
+</html>

--- a/RemoteControlApi/wwwroot/send.html
+++ b/RemoteControlApi/wwwroot/send.html
@@ -6,33 +6,36 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Send Notification</h1>
-  <form id="notifyForm">
-    <label>ID (optional)
-      <input id="id" name="id">
-    </label>
-    <label>Title
-      <input id="title" name="title" required>
-    </label>
-    <label>Body
-      <textarea id="body" name="body" required></textarea>
-    </label>
-    <button type="submit">Send</button>
-  </form>
+    <h1>Send Notification</h1>
+    <form id="notifyForm" enctype="multipart/form-data">
+      <label>ID (optional)
+        <input id="id" name="id">
+      </label>
+      <label>Title
+        <input id="title" name="title" required>
+      </label>
+      <label>Body
+        <textarea id="body" name="body" required></textarea>
+      </label>
+      <label>File
+        <input id="file" name="file" type="file">
+      </label>
+      <button type="submit">Send</button>
+    </form>
   <pre id="result"></pre>
   <script>
-    const form = document.getElementById('notifyForm');
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const res = await fetch('/api/control/send-notification', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: form.id.value, title: form.title.value, body: form.body.value })
+      const form = document.getElementById('notifyForm');
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const data = new FormData(form);
+        const res = await fetch('/api/control/send-notification', {
+          method: 'POST',
+          body: data
+        });
+        const json = await res.json();
+        document.getElementById('result').textContent = JSON.stringify(json, null, 2);
+        form.reset();
       });
-      const json = await res.json();
-      document.getElementById('result').textContent = JSON.stringify(json, null, 2);
-      form.reset();
-    });
   </script>
 </body>
 </html>

--- a/RemoteControlApi/wwwroot/style.css
+++ b/RemoteControlApi/wwwroot/style.css
@@ -4,3 +4,8 @@ input, textarea { width: 100%; padding: 8px; margin-top: 4px; }
 button { padding: 8px 16px; }
 ul { list-style: none; padding: 0; }
 li { margin-bottom: 8px; background: #f2f2f2; padding: 8px; }
+.preview-container { margin-top: 8px; }
+.preview-container img,
+.preview-container video,
+.preview-container iframe,
+.preview-container audio { max-width: 100%; display: block; margin-top: 4px; }

--- a/RemoteControlApi/wwwroot/style.css
+++ b/RemoteControlApi/wwwroot/style.css
@@ -1,0 +1,6 @@
+body { font-family: Arial, sans-serif; max-width: 600px; margin: 20px auto; }
+label { display: block; margin-bottom: 10px; }
+input, textarea { width: 100%; padding: 8px; margin-top: 4px; }
+button { padding: 8px 16px; }
+ul { list-style: none; padding: 0; }
+li { margin-bottom: 8px; background: #f2f2f2; padding: 8px; }


### PR DESCRIPTION
## Summary
- Prevent null path values in download endpoints by verifying file paths before combining
- Simplifies subsequent file operations by returning early when the path is missing

## Testing
- `dotnet build RemoteControlApi/RemoteControlApi.csproj`
- `dotnet test RemoteControlApi.sln`
- `dotnet run --project RemoteControlApi`

------
https://chatgpt.com/codex/tasks/task_e_68bba2c192f0832b9516bf9e49411c71