### PR TITLE
refactor: expose send notification params for swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Sau khi chạy ứng dụng, truy cập `http://localhost:5067/swagger` (hoặc 
 Ví dụ request gửi thông báo ở dạng JSON:
 
 ```
-POST http://localhost:5067/api/control/send-notification
+POST http://localhost:5067/api/control/send-notification-json
 Content-Type: application/json
 
 {
@@ -30,10 +30,11 @@ Content-Type: application/json
 }
 ```
 
-Để gửi kèm tệp, chuyển sang tab *form-data* và thêm các trường `title`, `body` cùng trường tệp `file`.
+Để gửi kèm tệp, gọi endpoint `send-notification-form`, chuyển sang tab *form-data* và thêm các trường `title`, `body` cùng trường tệp `file`.
 
 ## Các endpoint chính
-- `POST /api/control/send-notification` : gửi thông báo (JSON hoặc form-data).
+- `POST /api/control/send-notification-json` : gửi thông báo dạng JSON.
+- `POST /api/control/send-notification-form` : gửi thông báo kèm tệp (form-data).
 - `GET /api/control/get-notifications` : lấy danh sách thông báo.
 - `GET /api/control/notifications-stream` : stream thông báo (SSE).
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,19 @@ Content-Type: application/json
 
 Để gửi kèm tệp, gọi endpoint `send-notification-form`, chuyển sang tab *form-data* và thêm các trường `title`, `body` cùng trường tệp `file`.
 
+Ví dụ lấy và xoá thông báo trên Postman:
+
+```
+GET http://localhost:5067/api/control/get-notifications?clientId=device1
+
+POST http://localhost:5067/api/control/clear-notifications?clientId=device1
+```
+
 ## Các endpoint chính
 - `POST /api/control/send-notification-json` : gửi thông báo dạng JSON.
 - `POST /api/control/send-notification-form` : gửi thông báo kèm tệp (form-data).
-- `GET /api/control/get-notifications` : lấy danh sách thông báo.
+- `GET /api/control/get-notifications?clientId=YOUR_ID` : lấy thông báo của từng client.
+- `POST /api/control/clear-notifications?clientId=YOUR_ID` : đánh dấu thông báo đã xem cho client đó.
 - `GET /api/control/notifications-stream` : stream thông báo (SSE).
 
-Tham khảo thêm trong Swagger tại `/swagger`.
+Mỗi thiết bị nên dùng một `clientId` riêng, việc xoá của một client sẽ không ảnh hưởng đến client khác. Tham khảo thêm trong Swagger tại `/swagger`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-﻿RemoteControlApi
+# RemoteControlApi
+
+API cho phép gửi và nhận thông báo. Bạn có thể thử nghiệm nhanh bằng giao diện tại `wwwroot/send.html`, Swagger hoặc Postman.
+
+## Chạy dự án
+
+```bash
+# yêu cầu .NET 8 SDK
+cd RemoteControlApi
+dotnet run
+```
+
+Mặc định API chạy tại `http://localhost:5067` (hoặc port hiển thị trên console).
+
+## Thử nghiệm API
+
+### Swagger
+Sau khi chạy ứng dụng, truy cập `http://localhost:5067/swagger` (hoặc port hiển thị trên console) để thử các endpoint trực tiếp trên trình duyệt.
+
+### Postman
+Ví dụ request gửi thông báo ở dạng JSON:
+
+```
+POST http://localhost:5067/api/control/send-notification
+Content-Type: application/json
+
+{
+  "title": "Test",
+  "body": "Hello from Postman"
+}
+```
+
+Để gửi kèm tệp, chuyển sang tab *form-data* và thêm các trường `title`, `body` cùng trường tệp `file`.
+
+## Các endpoint chính
+- `POST /api/control/send-notification` : gửi thông báo (JSON hoặc form-data).
+- `GET /api/control/get-notifications` : lấy danh sách thông báo.
+- `GET /api/control/notifications-stream` : stream thông báo (SSE).
+
+Tham khảo thêm trong Swagger tại `/swagger`.

--- a/RemoteControlApi/Controllers/ControlController.cs
+++ b/RemoteControlApi/Controllers/ControlController.cs
@@ -73,14 +73,14 @@ namespace RemoteControlApi.Controllers
 
 
 
-        [HttpPost("send-notification")]
+        [HttpPost("send-notification-json")]
         [Consumes("application/json")]
         public IActionResult SendNotificationJson([FromBody] NotificationMessage message)
         {
             return HandleNotification(message);
         }
 
-        [HttpPost("send-notification")]
+        [HttpPost("send-notification-form")]
         [Consumes("multipart/form-data")]
         public async Task<IActionResult> SendNotificationForm([FromForm] NotificationMessage message, IFormFile? file)
         {


### PR DESCRIPTION
## Summary
- split send-notification into JSON and form-data variants so fields show in Swagger
- document testing via Swagger or Postman

## Testing
- `dotnet build RemoteControlApi/RemoteControlApi.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bfc9727660832bbebeceead6170ee1